### PR TITLE
Add subDirAsRoot option to specify a subdirectory as the root directory of the packaged output

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ export interface Options {
    * @default undefined
    */
   password?: string;
+  /**
+   * Subdirectory to be used as the root directory of the packaged output
+   * @default undefined
+   */
+  subDirAsRoot?: string;
 }
 ```
 
@@ -82,6 +87,7 @@ export default defineConfig({
   plugins: [
     zipPack({
       /* options */
+      subDirAsRoot: './dist/subdir'
     }),
   ],
 });

--- a/playground/vite/vite.config.js
+++ b/playground/vite/vite.config.js
@@ -7,7 +7,25 @@ import zipPack from "../../dist/vite";
 export default defineConfig({
   plugins: [
     vue(),
-    // zip pack
+    // zip pack -- pack assets folder to zip
+    zipPack({
+      inDir: `./dist/assets`,
+      outDir: `./distpack`,
+      outFileName: `dist_${new Date().getTime()}.zip`,
+      filter: (fileName, filePath, isDirectory) => {
+        // config目錄以及config目錄下的文件不打包
+        if (filePath.includes("config")) {
+          return false;
+        }
+        return true;
+      },
+      subDirAsRoot: "./dist/assets",
+    }),
+
+    /**
+     * default zip pack -- pack dist folder to zip
+     */
+    /*
     zipPack({
       inDir: `./dist`,
       outDir: `./distpack`,
@@ -19,7 +37,7 @@ export default defineConfig({
         }
         return true;
       },
-      subDirAsRoot: './dist/subdir'
     }),
+    */
   ],
 });

--- a/playground/vite/vite.config.js
+++ b/playground/vite/vite.config.js
@@ -19,6 +19,7 @@ export default defineConfig({
         }
         return true;
       },
+      subDirAsRoot: './dist/subdir'
     }),
   ],
 });

--- a/playground/vuecli-webpack/vue.config.js
+++ b/playground/vuecli-webpack/vue.config.js
@@ -16,6 +16,7 @@ module.exports = defineConfig({
           }
           return true;
         },
+        subDirAsRoot: './dist/subdir'
       }),
     ];
 

--- a/playground/vuecli-webpack/vue.config.js
+++ b/playground/vuecli-webpack/vue.config.js
@@ -6,7 +6,7 @@ module.exports = defineConfig({
     let plugins = [
       // zip pack
       zipPack({
-        inDir: `./dist`,
+        inDir: `./dist/assets`,
         outDir: `./distpack`,
         outFileName: `dist_${new Date().getTime()}.zip`,
         filter: (fileName, filePath, isDirectory) => {
@@ -16,8 +16,26 @@ module.exports = defineConfig({
           }
           return true;
         },
-        subDirAsRoot: './dist/subdir'
+        subDirAsRoot: "./dist/assets",
       }),
+
+      /**
+       * default zip pack -- pack dist folder to zip
+       */
+      /*
+      zipPack({
+          inDir: `./dist`,
+          outDir: `./distpack`,
+          outFileName: `dist_${new Date().getTime()}.zip`,
+          filter: (fileName, filePath, isDirectory) => {
+            // config目錄以及config目錄下的文件不打包
+            if (filePath.includes("config")) {
+              return false;
+            }
+            return true;
+          },
+        }),
+      */
     ];
 
     return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,13 +21,15 @@ const DEFAULT_OPTIONS = {
   done: () => {},
   filter: () => true,
   password: undefined,
+  subDirAsRoot: undefined,
 };
 
 async function addFilesToZipWriter(
   zipWriter: ZipWriter<Blob>,
   inDir: string,
   pathPrefix: string,
-  filter: Function
+  filter: Function,
+  subDirAsRoot?: string
 ) {
   const listOfFiles = await fsPromises.readdir(inDir);
 
@@ -38,7 +40,7 @@ async function addFilesToZipWriter(
     if (file.isDirectory()) {
       if (!filter(fileName, filePath, true)) continue;
       // 迭代下一級目錄
-      await addFilesToZipWriter(zipWriter, filePath, pathPrefix, filter);
+      await addFilesToZipWriter(zipWriter, filePath, pathPrefix, filter, subDirAsRoot);
     } else {
       if (filter(fileName, filePath, false)) {
         const fileBuffer: Buffer = await fsPromises.readFile(filePath);
@@ -46,6 +48,9 @@ async function addFilesToZipWriter(
           type: getMimeType(fileName),
         });
         let _filePath = removePathLevel(filePath, 0);
+        if (subDirAsRoot && filePath.startsWith(subDirAsRoot)) {
+          _filePath = filePath.substring(subDirAsRoot.length + 1);
+        }
         let zipFilePath = pathPrefix ? join(pathPrefix, _filePath) : _filePath;
         zipWriter.add(zipFilePath, new BlobReader(fileBlob));
       }
@@ -88,7 +93,7 @@ export const unpluginFactory: UnpluginFactory<Options | undefined> = (
 ) => ({
   name: "unplugin-dist-zip-pack",
   buildEnd: async () => {
-    const { inDir, outDir, outFileName, pathPrefix, done, filter, password } = {
+    const { inDir, outDir, outFileName, pathPrefix, done, filter, password, subDirAsRoot } = {
       ...DEFAULT_OPTIONS,
       ...options,
     };
@@ -118,7 +123,7 @@ export const unpluginFactory: UnpluginFactory<Options | undefined> = (
         isCompress = true;
 
         // 遍歷目錄
-        await addFilesToZipWriter(zipWriter, inDir, pathPrefix, filter);
+        await addFilesToZipWriter(zipWriter, inDir, pathPrefix, filter, subDirAsRoot);
         let result = await zipWriter.close();
         console.log("Creating zip archive.");
         await createZipFile(result, outDir, outFileName, done);

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,4 +41,9 @@ export interface Options {
    * @default undefined
    */
   password?: string;
+  /**
+   * Subdirectory to be used as the root directory of the packaged output
+   * @default undefined
+   */
+  subDirAsRoot?: string;
 }


### PR DESCRIPTION
Add support for setting a subdirectory as the root directory of the packaged output.

* **src/types.ts**
  - Add a new optional property `subDirAsRoot` to the `Options` interface to specify a subdirectory as the root directory of the packaged output.

* **src/index.ts**
  - Update the `DEFAULT_OPTIONS` object to include the new `subDirAsRoot` option with a default value of `undefined`.
  - Update the `addFilesToZipWriter` function to handle the `subDirAsRoot` option, adjusting the path prefix accordingly.
  - Update the `unpluginFactory` function to pass the `subDirAsRoot` option to the `addFilesToZipWriter` function.

* **README.md**
  - Add documentation for the new `subDirAsRoot` option in the `Options` section.
  - Provide an example of using the `subDirAsRoot` option in the Vite configuration.

* **playground/vite/vite.config.js**
  - Add an example of using the `subDirAsRoot` option in the Vite configuration.

* **playground/vuecli-webpack/vue.config.js**
  - Add an example of using the `subDirAsRoot` option in the Vue CLI configuration.

